### PR TITLE
Try 3 times if a get request times out before raising exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ Namely associates a subdomain with your organization. For example, if
 your account is at `http://your-organization.namely.com/`, your
 subdomain would be `"your-organization"`.
 
+## Configuration
+
+You can override default configuration using `Namely.configuration` like:
+
+```Ruby
+Namely.configuration do |config|
+
+  # While returning paged results, which http codes should be rescued and
+  # retried? Defaults to none.
+  config.http_codes_to_retry = [504] # gateway timeout
+
+  # The number of times to retry the requests rescued above. Default is 0
+  config.retries = 2
+end
+```
+
 ## Usage Examples
 
 Once you've created a connection you can use it to access your data.

--- a/lib/namely.rb
+++ b/lib/namely.rb
@@ -2,6 +2,7 @@ require "json"
 require "ostruct"
 require "rest_client"
 
+require "namely/configuration"
 require "namely/authenticator"
 require "namely/exceptions"
 require "namely/resource_gateway"

--- a/lib/namely/configuration.rb
+++ b/lib/namely/configuration.rb
@@ -1,0 +1,56 @@
+module Namely
+  class Configuration
+
+    # The http codes that should be retried if a request fails while returning
+    # a page in paged results. Number of times to retry specified in {#retries}.
+    # Defaults to an empty Array.
+    #
+    # @see #retries
+    # @return [Array<Integer>] the http codes to retry for a failed request
+    attr_reader :http_codes_to_retry
+
+    # Specifies the http codes of failed GET requests encountered while paging
+    # that should be retried.
+    #
+    # @param codes [Array<Integer>, Integer] http codes to retry
+    def http_codes_to_retry=(codes)
+      @http_codes_to_retry = Array(codes).map(&:to_int)
+    end
+
+    # Controls the number of times that a request for a page that failed while
+    # returning paged results with one of the http codes listed in
+    # {#http_codes_to_retry} will be retried before raising
+    # an exception. 0 by default.
+    #
+    # @return [Integer] number of times to retry request.
+    attr_accessor :retries
+
+    def initialize
+      @http_codes_to_retry = []
+      @retries = 0
+    end
+  end
+
+  # @return [Namely::Configuration] Namely's current configuration
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  # Set Namely's configuration
+  # @param config [Namely::Configuration]
+  def self.configuration=(config)
+    @configuration = config
+  end
+
+  # Modify Namely's current configuration
+  # @yieldparam [Namely::Configuration] config current Namely config
+  # ```
+  # Namely.configure do |config|
+  #   config.retries = 3
+  # end
+  # ```
+  def self.configure
+    yield configuration
+  end
+end
+

--- a/lib/namely/resource_gateway.rb
+++ b/lib/namely/resource_gateway.rb
@@ -44,7 +44,7 @@ module Namely
         params = {}
 
         loop do
-          objects = get("/#{endpoint}", params)[resource_name]
+          objects = with_retry { get("/#{endpoint}", params)[resource_name] }
           break if objects.empty?
 
           objects.each { |o| y << o }
@@ -73,14 +73,18 @@ module Namely
       )
     end
 
-    def get(path, params = {})
+    def with_retry
       retries ||= 0
+      yield
+    rescue RestClient::Exception => e
+      raise unless Namely.configuration.http_codes_to_retry.include?(e.http_code)
+      retry if (retries += 1) < Namely.configuration.retries
+      raise
+    end
+
+    def get(path, params = {})
       params.merge!(access_token: access_token)
       JSON.parse(RestClient.get(url(path), accept: :json, params: params))
-
-    rescue RestClient::GatewayTimeout
-      retry if (retries += 1) < 3
-      raise
     end
 
     def head(path, params = {})

--- a/lib/namely/resource_gateway.rb
+++ b/lib/namely/resource_gateway.rb
@@ -74,8 +74,13 @@ module Namely
     end
 
     def get(path, params = {})
+      retries ||= 0
       params.merge!(access_token: access_token)
       JSON.parse(RestClient.get(url(path), accept: :json, params: params))
+
+    rescue RestClient::GatewayTimeout
+      retry if (retries += 1) < 3
+      raise
     end
 
     def head(path, params = {})

--- a/spec/namely/configuration_spec.rb
+++ b/spec/namely/configuration_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+describe Namely::Configuration do
+
+  describe "#http_codes_to_retry" do
+    it "is empty array by default" do
+      expect(Namely.configuration.http_codes_to_retry).to eq []
+    end
+
+    it "accepts an array of intergers" do
+      expected_result = http_codes = [504, 502]
+
+      Namely.configure { |config| config.http_codes_to_retry = http_codes }
+
+      expect(Namely.configuration.http_codes_to_retry).to eq expected_result
+    end
+
+    it "accepts a single integer" do
+      http_code = 504
+      expected_return = [http_code]
+
+      Namely.configure { |config| config.http_codes_to_retry = http_code }
+
+      expect(Namely.configuration.http_codes_to_retry).to eq expected_return
+    end
+  end
+
+  describe "#retries" do
+    it "is 0 by default" do
+      expect(Namely.configuration.retries).to eq 0
+    end
+
+    it "accepts an interger representing the number of retries" do
+      expected_result = number_of_retries = 3
+
+      Namely.configure { |config| config.retries = number_of_retries }
+
+      expect(Namely.configuration.retries).to eq expected_result
+    end
+  end
+end

--- a/spec/namely/resource_gateway_spec.rb
+++ b/spec/namely/resource_gateway_spec.rb
@@ -74,7 +74,10 @@ describe Namely::ResourceGateway do
         expect(ids).to eq(['123-456', '456-789'])
       end
 
-      it "makes 3 attempts if the api returns a timeout" do
+      it "retries http failures given the configured codes and number of retries" do
+        Namely.configuration.retries = 3
+        Namely.configuration.http_codes_to_retry = [504]
+
         stub_request(:get, "https://#{subdomain}.namely.com/api/v1/widgets").
           with(query: { access_token: access_token }).to_return(status:504).times(2).
           then.to_return(body: { widgets: [ id: "123-456" ] }.to_json)
@@ -92,7 +95,10 @@ describe Namely::ResourceGateway do
         expect(ids).to eq(['123-456', '456-789'])
       end
 
-      it "raises a timeout exception if it times out more that 3 times" do
+      it "raises an exception if exceeds configured retry number" do
+        Namely.configuration.retries = 3
+        Namely.configuration.http_codes_to_retry = [504]
+
         stub_request(:get, "https://#{subdomain}.namely.com/api/v1/widgets").
           with(query: { access_token: access_token }).to_return(status: 504)
 

--- a/spec/namely/resource_gateway_spec.rb
+++ b/spec/namely/resource_gateway_spec.rb
@@ -73,6 +73,32 @@ describe Namely::ResourceGateway do
 
         expect(ids).to eq(['123-456', '456-789'])
       end
+
+      it "makes 3 attempts if the api returns a timeout" do
+        stub_request(:get, "https://#{subdomain}.namely.com/api/v1/widgets").
+          with(query: { access_token: access_token }).to_return(status:504).times(2).
+          then.to_return(body: { widgets: [ id: "123-456" ] }.to_json)
+
+        stub_request(:get, "https://#{subdomain}.namely.com/api/v1/widgets").
+          with(query: { access_token: access_token, after: "123-456" }).
+          to_return(body: { widgets: [ id: "456-789" ] }.to_json)
+
+        stub_request(:get, "https://#{subdomain}.namely.com/api/v1/widgets").
+          with(query: { access_token: access_token, after: "456-789" }).
+          to_return(body: { widgets: [ ] }.to_json)
+
+        ids = gateway.json_index.map { |h| h['id'] }
+
+        expect(ids).to eq(['123-456', '456-789'])
+      end
+
+      it "raises a timeout exception if it times out more that 3 times" do
+        stub_request(:get, "https://#{subdomain}.namely.com/api/v1/widgets").
+          with(query: { access_token: access_token }).to_return(status: 504)
+
+        expect { gateway.json_index.map { |h| h['id'] } }.
+          to raise_error(RestClient::GatewayTimeout)
+      end
     end
   end
 


### PR DESCRIPTION
## Why

resolves #47

While using `connection.profiles.all` occasionally the namely API will return a 504 gateway timeout status while retrieving one of the pages. This raises an exception and derails the (sometimes lengthy) process of retrieving all of the paged results.

## What

This rescues the gateway timeout exception and retries 3 times before re raising it.

## Caveats

Right now this is just on the "get" request in the gem... but could be abstracted out and used for the other request types as well in the future (if needed)

This is a proof of concept... we may want to add it to the documentation if it's to be adopted?