### PR TITLE
Fix configuration example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ subdomain would be `"your-organization"`.
 You can override default configuration using `Namely.configuration` like:
 
 ```Ruby
-Namely.configuration do |config|
+Namely.configure do |config|
 
   # While returning paged results, which http codes should be rescued and
   # retried? Defaults to none.


### PR DESCRIPTION
This PR fixes what looks like a typo in the Configuration section of the readme.