### PR TITLE
Add the ability to Get Groups from Group Type

### DIFF
--- a/lib/namely/collection.rb
+++ b/lib/namely/collection.rb
@@ -71,6 +71,12 @@ module Namely
       raise NoSuchModelError, "Can't find any #{endpoint} with id \"#{id}\""
     end
 
+    def find_from(id, find_from=nil)
+      resource_gateway.json_find_from(id, find_from).map { |model| build(model) }
+    rescue RestClient::ResourceNotFound
+      raise NoSuchModelError, "Can't find any #{endpoint} with id \"#{id}\""
+    end
+
     private
 
     attr_reader :resource_gateway

--- a/lib/namely/connection.rb
+++ b/lib/namely/connection.rb
@@ -53,7 +53,7 @@ module Namely
     # Return a Collection of job tiers.
     #
     # @return [Collection]
-    def job_tiers
+    def group_types
       collection("group_types")
     end
 
@@ -84,12 +84,10 @@ module Namely
     def reports
       collection("reports")
     end
-    
-    
+
     def collection(endpoint, options = {})
       Namely::Collection.new(gateway(endpoint, options))
     end
-
 
     private
 

--- a/lib/namely/connection.rb
+++ b/lib/namely/connection.rb
@@ -77,14 +77,16 @@ module Namely
     def reports
       collection("reports")
     end
+    
+    
+    def collection(endpoint, options = {})
+      Namely::Collection.new(gateway(endpoint, options))
+    end
+
 
     private
 
     attr_reader :access_token, :subdomain
-
-    def collection(endpoint, options = {})
-      Namely::Collection.new(gateway(endpoint, options))
-    end
 
     def gateway(endpoint, options = {})
       ResourceGateway.new(options.merge(

--- a/lib/namely/connection.rb
+++ b/lib/namely/connection.rb
@@ -54,6 +54,13 @@ module Namely
     #
     # @return [Collection]
     def job_tiers
+      collection("group_types")
+    end
+
+    # Return a Collection of job tiers.
+    #
+    # @return [Collection]
+    def job_tiers
       collection("job_tiers")
     end
 

--- a/lib/namely/resource_gateway.rb
+++ b/lib/namely/resource_gateway.rb
@@ -13,6 +13,10 @@ module Namely
       paged ? json_index_paged : json_index_all
     end
 
+    def json_find_from(id, find_from)
+      get("/#{endpoint}/#{id}/#{find_from}")[find_from]
+    end
+
     def json_show(id)
       get("/#{endpoint}/#{id}")[resource_name].first
     end

--- a/lib/namely/version.rb
+++ b/lib/namely/version.rb
@@ -1,3 +1,3 @@
 module Namely
-  VERSION = '0.2.5'
+  VERSION = '0.2.5.17'
 end


### PR DESCRIPTION
This PR adds:

- The ability to get  Groups from Group Type `GET /group_types/{id}/groups`
- To fetch a collection directly (exposes the Namely::Connection#collection method

Based on: https://developers.namely.com/1.0/groups-and-teams/get-groups-from-group-type