### PR TITLE
[PG-3] Add Codacy badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Namely
+ 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/32905cacc6d74067b3319a5d477af845)](https://app.codacy.com/gh/namely/ruby-client/dashboard)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/32905cacc6d74067b3319a5d477af845)](https://app.codacy.com/gh/namely/ruby-client/dashboard)
 
 [![Travis](https://travis-ci.org/namely/ruby-client.svg?branch=master)](https://travis-ci.org/namely/ruby-client/builds)
 [![Code Climate](https://codeclimate.com/github/namely/ruby-client/badges/gpa.svg)](https://codeclimate.com/github/namely/ruby-client)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
  
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/32905cacc6d74067b3319a5d477af845)](https://app.codacy.com/gh/namely/ruby-client/dashboard)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/32905cacc6d74067b3319a5d477af845)](https://app.codacy.com/gh/namely/ruby-client/dashboard)
-
 [![Travis](https://travis-ci.org/namely/ruby-client.svg?branch=master)](https://travis-ci.org/namely/ruby-client/builds)
 [![Code Climate](https://codeclimate.com/github/namely/ruby-client/badges/gpa.svg)](https://codeclimate.com/github/namely/ruby-client)
 


### PR DESCRIPTION

# What does this do?

This PR adds the Codacy badges to the README.md

# Why are we doing this?

The Codacy badges provide an easy at-a-glance view of the code quality and coverage for the repository and increase awareness of quality goals.

Please drop in on the #codacy-discussion channel in Slack if you have any questions.